### PR TITLE
Corrected and fixed formatting

### DIFF
--- a/docs/t-sql/language-elements/TOC.md
+++ b/docs/t-sql/language-elements/TOC.md
@@ -4,7 +4,7 @@
 # [CREATE DIAGNOSTICS SESSION](create-diagnostics-session-transact-sql.md)  
 # [NULL and UNKNOWN](null-and-unknown-transact-sql.md)  
 # [USE](use-transact-sql.md)  
-# [Backslash](sql-server-utilities-statements-backslash.md)  
+# [Backslash (Line Continuation)](sql-server-utilities-statements-backslash.md)  
 # [GO](sql-server-utilities-statements-go.md)  
 
 # [Control-of-Flow](control-of-flow.md)  

--- a/docs/t-sql/language-elements/sql-server-utilities-statements-backslash.md
+++ b/docs/t-sql/language-elements/sql-server-utilities-statements-backslash.md
@@ -102,8 +102,8 @@ def AS [ColumnResult];
  [Data Types &#40;Transact-SQL&#41;](../../t-sql/data-types/data-types-transact-sql.md)   
  [Built-in Functions &#40;Transact-SQL&#41;](~/t-sql/functions/functions.md)   
  [Operators &#40;Transact-SQL&#41;](../../t-sql/language-elements/operators-transact-sql.md)   
- [&#40;Divide&#41; &#40;Transact-SQL&#41;](../../t-sql/language-elements/divide-transact-sql.md)   
- [&#40;Divide and Assignment&#41; &#40;Transact-SQL&#41;](../../t-sql/language-elements/divide-equals-transact-sql.md)   
+ [&#40;Division&#41; &#40;Transact-SQL&#41;](../../t-sql/language-elements/divide-transact-sql.md)   
+ [&#40;Division Assignment&#41; &#40;Transact-SQL&#41;](../../t-sql/language-elements/divide-equals-transact-sql.md)   
  [Compound Operators &#40;Transact-SQL&#41;](../../t-sql/language-elements/compound-operators-transact-sql.md)  
   
   

--- a/docs/t-sql/language-elements/sql-server-utilities-statements-backslash.md
+++ b/docs/t-sql/language-elements/sql-server-utilities-statements-backslash.md
@@ -1,7 +1,7 @@
 ---
-title: "(Backslash) (Transact-SQL) | Microsoft Docs"
+title: "Backslash (Line Continuation) (Transact-SQL) | Microsoft Docs"
 ms.custom: ""
-ms.date: "07/27/2017"
+ms.date: "11/09/2017"
 ms.prod: "sql-non-specified"
 ms.reviewer: ""
 ms.suite: ""
@@ -36,12 +36,10 @@ ms.author: "rickbyh"
 manager: "jhubbard"
 ms.workload: "On Demand"
 ---
-# SQL Server Utilities Statements - Backslash
+# Backslash (Line Continuation) (Transact-SQL)
 [!INCLUDE[tsql-appliesto-ss2008-asdb-xxxx-xxx_md](../../includes/tsql-appliesto-ss2008-asdb-xxxx-xxx-md.md)]
 
-  [!INCLUDE[ssNoVersion](../../includes/ssnoversion-md.md)] provides commands that are not [!INCLUDE[tsql](../../includes/tsql-md.md)] statements, but are recognized by the **sqlcmd** and **osql** utilities and [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] Code Editor. These commands can be used to facilitate the readability and execution of batches and scripts.  
-  
-\  breaks a long string constant into two or more lines for readability.  
+`\`  breaks a long string constant, character or binary, into two or more lines for readability.  
   
  ![Topic link icon](../../database-engine/configure-windows/media/topic-link.gif "Topic link icon") [Transact-SQL Syntax Conventions](../../t-sql/language-elements/transact-sql-syntax-conventions-transact-sql.md)  
   
@@ -61,15 +59,16 @@ ms.workload: "On Demand"
   
 ## Remarks  
  This command returns the first and continued sections of the string as one string, without the backslash.  
-  
- The backslash is not a [!INCLUDE[tsql](../../includes/tsql-md.md)] statement. It is a command that is recognized by the **sqlcmd** and **osql** utilities and [!INCLUDE[ssManStudioFull](../../includes/ssmanstudiofull-md.md)] Code Editor.  
-  
+
 ## Examples  
- The following example uses a backslash and a carriage return to split the string into two lines.  
+
+### A. Splitting a character string  
+
+The following example uses a backslash and a carriage return to split a character string into two lines.  
   
 ```  
 SELECT 'abc\  
-def' AS ColumnResult;  
+def' AS [ColumnResult];  
   
 ```  
   
@@ -80,13 +79,31 @@ def' AS ColumnResult;
  ------------  
  abcdef
  ```    
+
+### B. Splitting a binary string  
+
+The following example uses a backslash and a carriage return to split a binary string into two lines.  
+
+```  
+SELECT 0xabc\  
+def AS [ColumnResult];  
   
+```  
+  
+ [!INCLUDE[ssResult](../../includes/ssresult-md.md)]  
+  
+ ```  
+ ColumnResult  
+ ------------  
+ 0xABCDEF
+ ```    
+
 ## See Also  
  [Data Types &#40;Transact-SQL&#41;](../../t-sql/data-types/data-types-transact-sql.md)   
  [Built-in Functions &#40;Transact-SQL&#41;](~/t-sql/functions/functions.md)   
  [Operators &#40;Transact-SQL&#41;](../../t-sql/language-elements/operators-transact-sql.md)   
  [&#40;Divide&#41; &#40;Transact-SQL&#41;](../../t-sql/language-elements/divide-transact-sql.md)   
- [&#40;Divide EQUALS&#41; &#40;Transact-SQL&#41;](../../t-sql/language-elements/divide-equals-transact-sql.md)   
+ [&#40;Divide and Assignment&#41; &#40;Transact-SQL&#41;](../../t-sql/language-elements/divide-equals-transact-sql.md)   
  [Compound Operators &#40;Transact-SQL&#41;](../../t-sql/language-elements/compound-operators-transact-sql.md)  
   
   


### PR DESCRIPTION
* Removed false statements related to `\` being a client tool feature and _not_ a feature of T-SQL. The line continuation character is indeed a feature of T-SQL as I proved in the following post: [Backslash (Line Continuation)](https://SqlQuantumLeap.com/2017/10/27/line-continuation-in-t-sql/)
* Renamed from "Backslash" to "Backslash (Line Continuation)" because, well, that's what it is ;-)
* Added example for splitting a binary string